### PR TITLE
Add Validation for Cloudprem Environment Selection

### DIFF
--- a/codepipeline.yml
+++ b/codepipeline.yml
@@ -4,7 +4,7 @@ Transform:
 - AWS::Serverless-2016-10-31
 
 Description: >-
-  CodePipeline resources required for Cloudprem pipelines
+  Lambda CodePipeline resources required for Cloudprem pipelines
 
 Metadata:
 

--- a/codepipeline_app.yml
+++ b/codepipeline_app.yml
@@ -4,7 +4,7 @@ Transform:
 - AWS::Serverless-2016-10-31
 
 Description: >-
-  CodePipeline resources required for Cloudprem pipelines
+  Regional CodePipeline resources required for Cloudprem pipelines
 
 Metadata:
 

--- a/git_pipeline.yml
+++ b/git_pipeline.yml
@@ -291,10 +291,10 @@ Resources:
             phases:
               install:
                 runtime-versions:
-                  golang: 1.14
+                  golang: 1.15
                 commands:
-                  - wget -O terraform.zip https://releases.hashicorp.com/terraform/0.14.4/terraform_0.14.4_linux_amd64.zip && unzip terraform.zip && mv terraform /bin && rm terraform.zip
-                  - wget -O /bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v0.26.4/terragrunt_linux_amd64 && chmod +x /bin/terragrunt
+                  - wget -O terraform.zip https://releases.hashicorp.com/terraform/0.14.10/terraform_0.14.10_linux_amd64.zip && unzip terraform.zip && mv terraform /bin && rm terraform.zip
+                  - wget -O /bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v0.29.2/terragrunt_linux_amd64 && chmod +x /bin/terragrunt
                   - aws_credentials=$(aws sts assume-role --role-arn ${DeploymentRole.Arn} --role-session-name "Terraform")
                   - export AWS_ACCESS_KEY_ID=$(echo $aws_credentials|jq '.Credentials.AccessKeyId'|tr -d '"')
                   - export AWS_SECRET_ACCESS_KEY=$(echo $aws_credentials|jq '.Credentials.SecretAccessKey'|tr -d '"')
@@ -326,7 +326,7 @@ Resources:
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Type: LINUX_CONTAINER
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        Image: aws/codebuild/standard:5.0
         PrivilegedMode: false
         EnvironmentVariables:
         - Name: Environment
@@ -367,10 +367,10 @@ Resources:
             phases:
               install:
                 runtime-versions:
-                  golang: 1.14
+                  golang: 1.15
                 commands:
-                  - wget -O terraform.zip https://releases.hashicorp.com/terraform/0.14.4/terraform_0.14.4_linux_amd64.zip && unzip terraform.zip && mv terraform /bin && rm terraform.zip
-                  - wget -O /bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v0.26.4/terragrunt_linux_amd64 && chmod +x /bin/terragrunt
+                  - wget -O terraform.zip https://releases.hashicorp.com/terraform/0.14.10/terraform_0.14.10_linux_amd64.zip && unzip terraform.zip && mv terraform /bin && rm terraform.zip
+                  - wget -O /bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v0.29.2/terragrunt_linux_amd64 && chmod +x /bin/terragrunt
                   - aws_credentials=$(aws sts assume-role --role-arn ${DeploymentRole.Arn} --role-session-name "Terraform")
                   - export AWS_ACCESS_KEY_ID=$(echo $aws_credentials|jq '.Credentials.AccessKeyId'|tr -d '"')
                   - export AWS_SECRET_ACCESS_KEY=$(echo $aws_credentials|jq '.Credentials.SecretAccessKey'|tr -d '"')
@@ -390,7 +390,7 @@ Resources:
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Type: LINUX_CONTAINER
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        Image: aws/codebuild/standard:5.0
         PrivilegedMode: false
         EnvironmentVariables:
         - Name: Environment

--- a/git_pipeline.yml
+++ b/git_pipeline.yml
@@ -1,7 +1,7 @@
 ---
 AWSTemplateFormatVersion: 2010-09-09
 Description: >
-  Cloudprem deployment pipeline
+  Environmental Cloudprem deployment pipeline
 
 Metadata:
   AWS::CloudFormation::Interface:
@@ -533,4 +533,12 @@ Outputs:
     Description: Webhook URL to enter into webhook configuration on your github config repository.
     Value: !GetAtt Webhook.Url
     Condition: UseWebhooks
+
+  PathLock:
+    Description: ->
+      Output to lock environments from colliding, if this triggers a rollback it's because you tried to use the same
+      environmental information twice in the same Region. You must create a new folder for each environment.
+    Value: 'true'
+    Export:
+      Name: !Join [ "", [ !Ref RepositoryPath, '' ] ]
   


### PR DESCRIPTION
The biggest issue we've seen with CloudPrem is the repeated use of the same environment value which causes terraform state collisions. There's nothing in the system that prevents this, it only errors out once terraform tries to actually run a plan which is quite deep in the pipeline and even when it does error out it is not clear what the issue is. This PR is an elegant solution to prevent this collision using CloudFormation's own rules. It will prevent a pipeline creation if one exists in the current region using the same repository path (which is what we use as the state key).

I initially tried to solve this issue with a Lambda and a CodePipeline stage but after weeks of working on it was starting to look more and more like a state machine and was getting far too complex and unreliable so I went with this simpler solution that achieves 98% of what we wanted in the first place.

Additionally I've upgraded our CodeBuild environment to the latest supported version of terraform and terragrunt which required a golang upgrade as well. There are also some text changes for better semantics. 

To QA:
Create a stack using any repository path and then try to create another one using the same path, it should not even start creating assets, you will get an error right at the beginning of the creation process about duplicate export values. I included a description in the export value so when investigated it should be clear what the error is and why it's happening. 