### PR TITLE
Replicated sequence and channel targeting and parameter refactors

### DIFF
--- a/git_pipeline.yml
+++ b/git_pipeline.yml
@@ -45,8 +45,6 @@ Metadata:
         default: "Which branch in the above-mentioned repository should we pull settings from?"
       RepositoryPath:
         default: "Which path in the above-mentioned repository should we pull settings from?"
-      RepositorySecret:
-        default: "If using webhooks, enter the authentication secret here."
       Identifier:
         default: "What prefix should we use for resource names if any?"
       OwnerName:
@@ -78,13 +76,6 @@ Parameters:
     Type: String
     Default: https://github.com/Dozuki/CloudPrem-Config.git
     Description: SSH/HTTP URL of the git repository containing the Dozuki parameters
-
-  RepositorySecret:
-    Type: String
-    NoEcho: true
-    Description:
-      If using Webhooks enter your webhook secret here, this will allow for auto-updating of your instances whenever
-      code is pushed to your config repository. If left blank webhooks will be disabled.
 
   RepositoryBranch:
     Type: String
@@ -155,8 +146,6 @@ Conditions:
 
   CreateResources: !Equals [ !Ref PipelineAction, 'Apply' ]
 
-  UseWebhooks: !Not [ !Equals [ !Ref RepositorySecret, "" ] ]
-
   UseManualApproval: !Equals [ !Ref ManualApprovalRequired, 'true' ]
 
   CodeCommit: !Equals [ !Ref UseCodeCommit, 'true' ]
@@ -181,19 +170,6 @@ Resources:
       Description: The contents of the Dozuki license file provided to you.
       Type: String
       Value: !Ref DozukiLicense
-
-  RepositoryWebhookSecret:
-    Type: AWS::SSM::Parameter
-    Condition: UseWebhooks
-    Properties:
-      Name: !If
-        - IdentifierSet
-        - !Sub /${Identifier}/dozuki/${Environment}/webhooksecret
-        - !Sub /dozuki/${Environment}/webhooksecret
-      Description: The repository secret for webhook support.
-      Type: String
-      Value: !Ref RepositorySecret
-
 
 #   # ############### Roles ##############
 
@@ -707,24 +683,6 @@ Resources:
         Type: S3
         Location: !ImportValue cloudprem-bucket-name
 
-  Webhook:
-    Type: 'AWS::CodePipeline::Webhook'
-    Condition: UseWebhooks
-    Properties:
-      AuthenticationConfiguration:
-        SecretToken: !Ref RepositorySecret
-      Filters:
-        - JsonPath: "$.ref"
-          MatchEquals: refs/heads/{Branch}
-      Authentication: GITHUB_HMAC
-      TargetPipeline: !If
-      - DestroyResources
-      - !Ref ProjectDestroyPipeline
-      - !Ref ProjectApplyPipeline
-      TargetAction: Checkout
-      TargetPipelineVersion: 1
-      RegisterWithThirdParty: 'false'
-
 Outputs:
 
   LicenseParameterName:
@@ -752,11 +710,6 @@ Outputs:
   PipelineAction:
     Description: Terraform action that this pipeline executes
     Value: !Ref PipelineAction
-
-  WebhookURL:
-    Description: Webhook URL to enter into webhook configuration on your github config repository.
-    Value: !GetAtt Webhook.Url
-    Condition: UseWebhooks
 
   PathLock:
     Value: 'true'

--- a/git_pipeline.yml
+++ b/git_pipeline.yml
@@ -64,7 +64,6 @@ Parameters:
     Type: String
     MinLength: 50
     Description: The contents of the .rli license file provided by Dozuki
-    NoEcho: true
 
   UseCodeCommit:
     Type: String

--- a/git_pipeline.yml
+++ b/git_pipeline.yml
@@ -352,7 +352,7 @@ Resources:
                 commands:
                 - cd ${AWS::Region}/${RepositoryPath}/$MODULE_NAME
                 - terragrunt init --terragrunt-non-interactive
-                - terragrunt plan -out $CODEBUILD_SRC_DIR/plan.json ${command}
+                - terragrunt plan -out $CODEBUILD_SRC_DIR/plan.json
                 - 'export PLAN_OUTPUT=$(terragrunt show $CODEBUILD_SRC_DIR/plan.json -no-color | grep "Plan: ")'
                 - 'export PLAN_LOGS=${!PLAN_OUTPUT:-No Changes}'
                 - echo "$PLAN_LOGS"
@@ -365,14 +365,6 @@ Resources:
                 - PLAN_LOGS
                 - CODEBUILD_BUILD_ID
               shell: bash
-          - overrides: !If
-              - OverrideRepositoryParameters
-              - !Sub -var 'identifier=${Identifier}' -var 'environment=${Environment}'
-              - ''
-            command: !If
-              - DestroyResources
-              - -destroy
-              - ''
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Type: LINUX_CONTAINER
@@ -383,6 +375,18 @@ Resources:
           Value: !Ref Environment
         - Name: TF_INPUT
           Value: 'true'
+        - Name: TF_VAR_identifier
+          Value: !Ref Identifier
+        - Name: TF_VAR_environment
+          Value: !Ref Environment
+        - Name: TF_VAR_replicated_app_sequence_number
+          Value: !Ref ReplicatedAppSequence
+        - Name: TF_VAR_replicated_channel
+          Value: !Ref ReplicatedChannel
+        - Name: TF_VAR_cf_template_version
+          Value: 1
+        - Name: TF_CLI_ARGS_plan
+          Value: !If [ DestroyResources, "-destroy", ""]
       LogsConfig:
         CloudWatchLogs:
           Status:  ENABLED
@@ -446,6 +450,16 @@ Resources:
         EnvironmentVariables:
         - Name: Environment
           Value: !Ref Environment
+        - Name: TF_VAR_identifier
+          Value: !Ref Identifier
+        - Name: TF_VAR_environment
+          Value: !Ref Environment
+        - Name: TF_VAR_replicated_app_sequence_number
+          Value: !Ref ReplicatedAppSequence
+        - Name: TF_VAR_replicated_channel
+          Value: !Ref ReplicatedChannel
+        - Name: TF_VAR_cf_template_version
+          Value: 1
       LogsConfig:
         CloudWatchLogs:
           Status:  ENABLED

--- a/git_pipeline.yml
+++ b/git_pipeline.yml
@@ -28,6 +28,11 @@ Metadata:
           - OverrideRepositoryParameters
           - PipelineAction
           - ManualApprovalRequired
+      - Label:
+          default: Application Bootstrap Options
+        Parameters:
+          - ReplicatedAppSequence
+          - ReplicatedChannel
     ParameterLabels:
       DozukiLicense:
         default: "Please enter your Dozuki license in the box below."
@@ -53,6 +58,10 @@ Metadata:
         default: "Which action should we execute?"
       ManualApprovalRequired:
         default: "Should we require manual approval for infrastructure changes?"
+      ReplicatedAppSequence:
+        default: "Should we bootstrap a specific replicated sequence when installing the app?"
+      ReplicatedChannel:
+        default: "Which channel is the above-mentioned sequence deployed to? (Note: This channel must be associated with your customer license)"
 
 Parameters:
 
@@ -130,6 +139,22 @@ Parameters:
     Description:
       If true a manual approval is required for each module that has infrastructure changes. This should probably be
       true for production stacks and false for dev stacks.
+
+  ReplicatedAppSequence:
+    Type: Number
+    Default: 0
+    MinValue: 0
+    MaxValue: 9999
+    Description:
+      When bootstrapping a fresh install of the app we can target a specific Replicated sequence number instead of just
+      installing whatever is the latest one associated with the channel described below.
+
+  ReplicatedChannel:
+    Type: String
+    Default: ""
+    Description:
+      When targeting a specific Replicated sequence number above, this is the channel where the sequence is deployed. You
+      only need to specify this if it's not the "default" channel associated with your license.
 
 Conditions:
 

--- a/git_pipeline.yml
+++ b/git_pipeline.yml
@@ -25,7 +25,6 @@ Metadata:
       - Label:
           default: Terraform Options
         Parameters:
-          - OverrideRepositoryParameters
           - PipelineAction
           - ManualApprovalRequired
       - Label:
@@ -52,8 +51,6 @@ Metadata:
         default: "What prefix should we use for resource names if any?"
       OwnerName:
         default: "What tag should we add to all resources to identify the stack owner if any?"
-      OverrideRepositoryParameters:
-        default: "Should we override the specified configuration settings in the repository with values set here?"
       PipelineAction:
         default: "Which action should we execute?"
       ManualApprovalRequired:
@@ -98,12 +95,6 @@ Parameters:
     Type: String
     Default: development
     Description: Path inside the git repository that contains the Dozuki parameters for this environment. Don't use the same path for multiple pipelines
-
-  OverrideRepositoryParameters:
-    Type: String
-    Default: true
-    AllowedValues: [ true, false ]
-    Description: Override 'identifier', 'region' and 'environment' parameters from the repository with the template parameters set here.
 
   PipelineAction:
     Type: String
@@ -159,8 +150,6 @@ Parameters:
 Conditions:
 
   IdentifierSet: !Not [ !Equals [ !Ref Identifier, "" ] ]
-
-  OverrideRepositoryParameters: !Equals [ !Ref OverrideRepositoryParameters, true ]
 
   DestroyResources: !Equals [ !Ref PipelineAction, 'Destroy' ]
 
@@ -334,8 +323,7 @@ Resources:
         Type: CODEPIPELINE
       Source:
         Type: CODEPIPELINE
-        BuildSpec: !Sub        
-          - |
+        BuildSpec: !Sub |
             version: 0.2
             phases:
               install:
@@ -436,12 +424,9 @@ Resources:
                 - terragrunt init --terragrunt-non-interactive
                 - ${command}
           - command: !If
-              - DestroyResources
-              - !If # We are using refresh before the destroy due to Terraform 0.14 bug https://github.com/terraform-aws-modules/terraform-aws-eks/issues/1162
-                - OverrideRepositoryParameters
-                - !Sub terragrunt refresh -var 'identifier=${Identifier}' -var 'environment=${Environment}' && terragrunt destroy -auto-approve -var 'identifier=${Identifier}' -var 'environment=${Environment}'
-                - terragrunt refresh && terragrunt destroy -auto-approve
-              - terragrunt apply $PLAN_PATH/plan.json
+            - DestroyResources
+            - terragrunt refresh && terragrunt destroy -auto-approve
+            - terragrunt apply $PLAN_PATH/plan.json
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Type: LINUX_CONTAINER


### PR DESCRIPTION
To make it easier for QA and customers we added the ability to target specific replicated sequence numbers and channels associated with their license to the terraform. This change allows them to set these variables at pipeline creation via CloudFormation instead of needing to do it in the `env.hcl` config of their environment. 

Additionally this has some major refactors in the way we invoke terraform itself and the CloudFormation in general:

1. We no longer use CLI options for input variables (i.e. `-var environment "dev"`)
   * This is done so we can pass variable content into the terraform universally regardless of which module is being executed. For example, `replicated_app_sequence_number` is only used in the logical module, so if we tried to pass that to every invocation of the planning and apply stage the terraform would error out and complain any time the physical stack was being executed. The solution to this is to either: 
     * pass through the variable from the physical stack
        * adds unnecessary bloat
     * disable terraform's complaining about input variables passed but not defined 
        * removes potentially important error handling
     * use environment variables to pass input. 
        * slightly more difficult debugging but much more elegant and the best-practice solution for this use case
2. Remove `OverrideRepository` paramater
   * In my testing and observing QA and customers deployments I've never seen this variable be set to anything other than true and on multiple occasions it has caused confusion. After thinking on it I realized It would never not be true and probably should not have been an option in the first place, so I removed it and we now override the configured variables always. 
3. Remove git web hook functionality
   * No one uses this functionality and it only serves to confuse users as we have webhooks within the app as well. My initial idea for this feature was to allow us to auto-update our managed stacks by pushing to the repo but as we use completely separate repos for each region this is not really a time saver. It can always be added back in later if we want to take advantage of auto-updating stacks on git push. 
4. No longer hiding the Dozuki license during environment creation.
   * Adding this to our original CF version of PC was a judgement call on my part in the first place as I know the license is a protected value but seeing as how it never leaves the AWS console and the customer always has access to this content anyway, hiding it seems to cause more potential issues than it solves. By showing it in the stack creation confirm stage we give the user one last opportunity to validate their input before creation. 
5. Add simple versioning to the CF template
   * When we update terraform in our infra HCL code we need a way to check whether the CodeBuild environment is up to date so I added an input variable `cf_template_version`. This will be hardcoded into the CloudFormation and passed to the terraform run via environment variable like everything else. The HCL code is configured to validate this value based on its current expectations. Right now we are on version 1, when we need to update our CodeBuild config again this will increment to 2 and so forth. Not using Semver, whole numbers are fine.
  