### PR TITLE
CloudFormation changes to support KOTS

### DIFF
--- a/codepipeline.yml
+++ b/codepipeline.yml
@@ -21,7 +21,7 @@ Metadata:
     LicenseUrl: LICENSE
     Labels: ['codepipeline']
     HomePageUrl: https://github.com/Dozuki/CloudPrem
-    SemanticVersion: 1.2.8
+    SemanticVersion: 1.2.13
     SourceCodeUrl: https://github.com/Dozuki/CloudPrem
 
 Parameters:

--- a/codepipeline_packaged.yml
+++ b/codepipeline_packaged.yml
@@ -19,7 +19,7 @@ Metadata:
     Labels:
     - codepipeline
     HomePageUrl: https://github.com/Dozuki/CloudPrem
-    SemanticVersion: 1.2.8
+    SemanticVersion: 1.2.13
     SourceCodeUrl: https://github.com/Dozuki/CloudPrem
 Parameters:
   SourceActionVersion:
@@ -81,6 +81,8 @@ Resources:
       OutputArtifactDetails:
         MaximumCount: 1
         MinimumCount: 1
+    Metadata:
+      SamResourceId: CustomSourceAction
   KeysBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Delete
@@ -88,6 +90,8 @@ Resources:
     Properties:
       BucketName:
         Fn::Sub: dozuki-ssh-keys-${AWS::Region}-${AWS::AccountId}
+    Metadata:
+      SamResourceId: KeysBucket
   KMSKey:
     Type: AWS::KMS::Key
     Properties:
@@ -115,6 +119,8 @@ Resources:
           - kms:GenerateDataKey*
           - kms:DescribeKey
           Resource: '*'
+    Metadata:
+      SamResourceId: KMSKey
   CreateSSHKeyFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -130,6 +136,8 @@ Resources:
       - S3CrudPolicy:
           BucketName:
             Ref: KeysBucket
+    Metadata:
+      SamResourceId: CreateSSHKeyFunction
   CreateSSHKey:
     Type: AWS::CloudFormation::CustomResource
     Version: '1.0'
@@ -144,6 +152,8 @@ Resources:
         Ref: AWS::Region
       KMSKey:
         Ref: KMSKey
+    Metadata:
+      SamResourceId: CreateSSHKey
   GitPullFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -152,7 +162,7 @@ Resources:
       Description: Custom source action for CodePipeline. Pulls the source code from
         any Git repository.
       Handler: lambda_function.lambda_handler
-      CodeUri: s3://dozuki-lambda/0681de66e51eb374e7e6af43f0d2b631
+      CodeUri: s3://dozuki-lambda/0b3832d234021c41a95553d8b13adfea
       Layers:
       - Fn::If:
         - IsGov
@@ -191,8 +201,12 @@ Resources:
             Schedule: rate(1 minute)
             Description: Fire CodePipeline custom action polling
             Enabled: true
+    Metadata:
+      SamResourceId: GitPullFunction
   AutoApproveTopic:
     Type: AWS::SNS::Topic
+    Metadata:
+      SamResourceId: AutoApproveTopic
   AutoApproveFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -219,6 +233,8 @@ Resources:
           Properties:
             Topic:
               Ref: AutoApproveTopic
+    Metadata:
+      SamResourceId: AutoApproveFunction
   S3ArtifactsBucket:
     Type: AWS::S3::Bucket
     DeletionPolicy: Delete
@@ -228,6 +244,8 @@ Resources:
         Fn::Sub: dozuki-codepipeline-${AWS::Region}-${AWS::AccountId}
       VersioningConfiguration:
         Status: Enabled
+    Metadata:
+      SamResourceId: S3ArtifactsBucket
 Outputs:
   PublicSSHKey:
     Description: Public SSH key for the Git CodePipeline source stage. Add the SSH

--- a/git_pipeline.yml
+++ b/git_pipeline.yml
@@ -121,15 +121,6 @@ Parameters:
       If true a manual approval is required for each module that has infrastructure changes. This should probably be
       true for production stacks and false for dev stacks.
 
-  ReplicatedAppSequence:
-    Type: Number
-    Default: 0
-    MinValue: 0
-    MaxValue: 9999
-    Description:
-      When bootstrapping a fresh install of the app we can target a specific Replicated sequence number instead of just
-      installing whatever is the latest one associated with the channel described below.
-
   ReplicatedChannel:
     Type: String
     Default: ""
@@ -342,8 +333,6 @@ Resources:
           Value: !Ref Identifier
         - Name: TF_VAR_environment
           Value: !Ref Environment
-        - Name: TF_VAR_replicated_app_sequence_number
-          Value: !Ref ReplicatedAppSequence
         - Name: TF_VAR_replicated_channel
           Value: !Ref ReplicatedChannel
         - Name: TF_VAR_cf_template_version
@@ -414,8 +403,6 @@ Resources:
           Value: !Ref Identifier
         - Name: TF_VAR_environment
           Value: !Ref Environment
-        - Name: TF_VAR_replicated_app_sequence_number
-          Value: !Ref ReplicatedAppSequence
         - Name: TF_VAR_replicated_channel
           Value: !Ref ReplicatedChannel
         - Name: TF_VAR_cf_template_version

--- a/git_pipeline.yml
+++ b/git_pipeline.yml
@@ -7,7 +7,7 @@ Metadata:
       - Label:
           default: Environment Configuration
         Parameters:
-          - DozukiLicense
+          - DozukiCustomerID
           - Environment
       - Label:
           default: Settings Repository Configuration
@@ -33,8 +33,8 @@ Metadata:
           - ReplicatedAppSequence
           - ReplicatedChannel
     ParameterLabels:
-      DozukiLicense:
-        default: "Please enter your Dozuki license in the box below."
+      DozukiCustomerID:
+        default: "Please enter your Dozuki Customer ID in the box below."
       Environment:
         default: "What environment tag should we use for this installation?"
       UseCodeCommit:
@@ -60,10 +60,11 @@ Metadata:
 
 Parameters:
 
-  DozukiLicense:
+  DozukiCustomerID:
     Type: String
-    MinLength: 50
-    Description: The contents of the .rli license file provided by Dozuki
+    MinLength: 10
+    MaxLength: 30
+    Description: The customer ID provided to you by Dozuki
 
   UseCodeCommit:
     Type: String
@@ -150,16 +151,16 @@ Mappings:
 
 Resources:
 
-  DozukiLicenseParameter:
+  DozukiCustomerIDParameter:
     Type: AWS::SSM::Parameter
     Properties:
       Name: !If
         - IdentifierSet
-        - !Sub /${Identifier}/dozuki/${Environment}/license
-        - !Sub /dozuki/${Environment}/license
-      Description: The contents of the Dozuki license file provided to you.
+        - !Sub /${Identifier}/dozuki/${Environment}/customer_id
+        - !Sub /dozuki/${Environment}/customer_id
+      Description: The customer ID for your Dozuki license.
       Type: String
-      Value: !Ref DozukiLicense
+      Value: !Ref DozukiCustomerID
 
 #   # ############### Roles ##############
 
@@ -675,9 +676,9 @@ Resources:
 
 Outputs:
 
-  LicenseParameterName:
-    Description: Name of the Dozuki license Parameter Store parameter
-    Value: !Ref DozukiLicenseParameter
+  CustomerIDParameterName:
+    Description: Name of the Dozuki Customer ID Parameter Store parameter
+    Value: !Ref DozukiCustomerIDParameter
 
   PlanCodeBuildProject:
     Description: Name of the Terraform plan CodeBuild project

--- a/git_pipeline.yml
+++ b/git_pipeline.yml
@@ -296,6 +296,8 @@ Resources:
                 runtime-versions:
                   golang: 1.15
                 commands:
+                  - curl -L https://storage.googleapis.com/kubernetes-release/release/v1.21.0/bin/linux/amd64/kubectl > /usr/local/bin/kubectl
+                  - chmod 755 /usr/local/bin/kubectl
                   - wget -O terraform.zip https://releases.hashicorp.com/terraform/1.1.8/terraform_1.1.8_linux_amd64.zip && unzip terraform.zip && mv terraform /bin && rm terraform.zip
                   - wget -O /bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v0.37.1/terragrunt_linux_amd64 && chmod +x /bin/terragrunt
                   - aws_credentials=$(aws sts assume-role --role-arn ${DeploymentRole.Arn} --role-session-name "Terraform")
@@ -375,6 +377,8 @@ Resources:
                 runtime-versions:
                   golang: 1.15
                 commands:
+                  - curl -L https://storage.googleapis.com/kubernetes-release/release/v1.21.0/bin/linux/amd64/kubectl > /usr/local/bin/kubectl
+                  - chmod 755 /usr/local/bin/kubectl
                   - wget -O terraform.zip https://releases.hashicorp.com/terraform/1.1.8/terraform_1.1.8_linux_amd64.zip && unzip terraform.zip && mv terraform /bin && rm terraform.zip
                   - wget -O /bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v0.37.1/terragrunt_linux_amd64 && chmod +x /bin/terragrunt
                   - aws_credentials=$(aws sts assume-role --role-arn ${DeploymentRole.Arn} --role-session-name "Terraform")

--- a/git_pipeline.yml
+++ b/git_pipeline.yml
@@ -338,7 +338,7 @@ Resources:
         - Name: TF_VAR_replicated_channel
           Value: !Ref ReplicatedChannel
         - Name: TF_VAR_cf_template_version
-          Value: 1
+          Value: 2
         - Name: TF_CLI_ARGS_plan
           Value: !If [ DestroyResources, "-destroy", ""]
       LogsConfig:
@@ -410,7 +410,7 @@ Resources:
         - Name: TF_VAR_replicated_channel
           Value: !Ref ReplicatedChannel
         - Name: TF_VAR_cf_template_version
-          Value: 1
+          Value: 2
       LogsConfig:
         CloudWatchLogs:
           Status:  ENABLED


### PR DESCRIPTION
Thankfully I was able to make the majority of the changes necessary in the terraform but some minor updates were needed in the CloudFormation anyway. Most notably the addition of `kubectl` as a dependency to the codebuild environment. 

I've also updated the CF to use the new CustomerID wording for the license parameter so it makes more sense. We no longer accept the full license file contents and instead only take the customer UUID. 