### PR TITLE
CodeBuild and CodePipeline changes to support S3 replication and version updates

### DIFF
--- a/git_pipeline.yml
+++ b/git_pipeline.yml
@@ -297,9 +297,9 @@ Resources:
                 runtime-versions:
                   golang: 1.15
                 commands:
-                  - curl -L https://storage.googleapis.com/kubernetes-release/release/v1.21.0/bin/linux/amd64/kubectl > /usr/local/bin/kubectl
+                  - curl -L https://storage.googleapis.com/kubernetes-release/release/v1.22.0/bin/linux/amd64/kubectl > /usr/local/bin/kubectl
                   - chmod 755 /usr/local/bin/kubectl
-                  - wget -O terraform.zip https://releases.hashicorp.com/terraform/1.1.8/terraform_1.1.8_linux_amd64.zip && unzip terraform.zip && mv terraform /bin && rm terraform.zip
+                  - wget -O terraform.zip https://releases.hashicorp.com/terraform/1.2.0/terraform_1.2.0_linux_amd64.zip && unzip terraform.zip && mv terraform /bin && rm terraform.zip
                   - wget -O /bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v0.37.1/terragrunt_linux_amd64 && chmod +x /bin/terragrunt
                   - aws_credentials=$(aws sts assume-role --role-arn ${DeploymentRole.Arn} --role-session-name "Terraform")
                   - export AWS_ACCESS_KEY_ID=$(echo $aws_credentials|jq '.Credentials.AccessKeyId'|tr -d '"')
@@ -339,7 +339,7 @@ Resources:
         - Name: TF_VAR_replicated_channel
           Value: !Ref ReplicatedChannel
         - Name: TF_VAR_cf_template_version
-          Value: 2
+          Value: 3
         - Name: TF_CLI_ARGS_plan
           Value: !If [ DestroyResources, "-destroy", ""]
       LogsConfig:
@@ -378,9 +378,9 @@ Resources:
                 runtime-versions:
                   golang: 1.15
                 commands:
-                  - curl -L https://storage.googleapis.com/kubernetes-release/release/v1.21.0/bin/linux/amd64/kubectl > /usr/local/bin/kubectl
+                  - curl -L https://storage.googleapis.com/kubernetes-release/release/v1.22.0/bin/linux/amd64/kubectl > /usr/local/bin/kubectl
                   - chmod 755 /usr/local/bin/kubectl
-                  - wget -O terraform.zip https://releases.hashicorp.com/terraform/1.1.8/terraform_1.1.8_linux_amd64.zip && unzip terraform.zip && mv terraform /bin && rm terraform.zip
+                  - wget -O terraform.zip https://releases.hashicorp.com/terraform/1.2.0/terraform_1.2.0_linux_amd64.zip && unzip terraform.zip && mv terraform /bin && rm terraform.zip
                   - wget -O /bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v0.37.1/terragrunt_linux_amd64 && chmod +x /bin/terragrunt
                   - aws_credentials=$(aws sts assume-role --role-arn ${DeploymentRole.Arn} --role-session-name "Terraform")
                   - export AWS_ACCESS_KEY_ID=$(echo $aws_credentials|jq '.Credentials.AccessKeyId'|tr -d '"')
@@ -411,7 +411,7 @@ Resources:
         - Name: TF_VAR_replicated_channel
           Value: !Ref ReplicatedChannel
         - Name: TF_VAR_cf_template_version
-          Value: 2
+          Value: 3
       LogsConfig:
         CloudWatchLogs:
           Status:  ENABLED

--- a/git_pipeline.yml
+++ b/git_pipeline.yml
@@ -299,7 +299,7 @@ Resources:
                 commands:
                   - curl -L https://storage.googleapis.com/kubernetes-release/release/v1.22.0/bin/linux/amd64/kubectl > /usr/local/bin/kubectl
                   - chmod 755 /usr/local/bin/kubectl
-                  - wget -O terraform.zip https://releases.hashicorp.com/terraform/1.2.0/terraform_1.2.0_linux_amd64.zip && unzip terraform.zip && mv terraform /bin && rm terraform.zip
+                  - wget -O terraform.zip https://releases.hashicorp.com/terraform/1.3.9/terraform_1.3.9_linux_amd64.zip && unzip terraform.zip && mv terraform /bin && rm terraform.zip
                   - wget -O /bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v0.37.1/terragrunt_linux_amd64 && chmod +x /bin/terragrunt
                   - aws_credentials=$(aws sts assume-role --role-arn ${DeploymentRole.Arn} --role-session-name "Terraform")
                   - export AWS_ACCESS_KEY_ID=$(echo $aws_credentials|jq '.Credentials.AccessKeyId'|tr -d '"')
@@ -380,7 +380,7 @@ Resources:
                 commands:
                   - curl -L https://storage.googleapis.com/kubernetes-release/release/v1.22.0/bin/linux/amd64/kubectl > /usr/local/bin/kubectl
                   - chmod 755 /usr/local/bin/kubectl
-                  - wget -O terraform.zip https://releases.hashicorp.com/terraform/1.2.0/terraform_1.2.0_linux_amd64.zip && unzip terraform.zip && mv terraform /bin && rm terraform.zip
+                  - wget -O terraform.zip https://releases.hashicorp.com/terraform/1.3.9/terraform_1.3.9_linux_amd64.zip && unzip terraform.zip && mv terraform /bin && rm terraform.zip
                   - wget -O /bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v0.37.1/terragrunt_linux_amd64 && chmod +x /bin/terragrunt
                   - aws_credentials=$(aws sts assume-role --role-arn ${DeploymentRole.Arn} --role-session-name "Terraform")
                   - export AWS_ACCESS_KEY_ID=$(echo $aws_credentials|jq '.Credentials.AccessKeyId'|tr -d '"')


### PR DESCRIPTION
Due to some additional features we need in terraform 1.2.x we need to update the terraform binary we install in our codebuild environments. Additionally since we upgraded to K8s v1.2.2 we should also upgrade our kubectl.

Lastly the template version was updated to reflect the new terraform restriction.